### PR TITLE
Set defaults for fields returned by Oodle API

### DIFF
--- a/internal/provider/oresource/base_resource.go
+++ b/internal/provider/oresource/base_resource.go
@@ -79,8 +79,8 @@ func (r *BaseResource[M, R]) Create(ctx context.Context, req resource.CreateRequ
 	createdMonitor, err := r.client.Create(clientModel)
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error Creating Monitor",
-			"Could not create monitor, unexpected error: "+err.Error(),
+			"Error Creating Model",
+			"Could not create model, unexpected error: "+err.Error(),
 		)
 		return
 	}

--- a/internal/provider/oresource/notifier/notifier_resource.go
+++ b/internal/provider/oresource/notifier/notifier_resource.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"terraform-provider-oodle/internal/oodlehttp"
 	"terraform-provider-oodle/internal/oodlehttp/clientmodels"
@@ -84,6 +86,8 @@ func (n *notifierResource) Schema(ctx context.Context, req resource.SchemaReques
 					},
 					"send_resolved": schema.BoolAttribute{
 						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
 						Description: "Send notifications when incident is resolved.",
 					},
 				},
@@ -103,6 +107,8 @@ func (n *notifierResource) Schema(ctx context.Context, req resource.SchemaReques
 					},
 					"title_link": schema.StringAttribute{
 						Optional:    true,
+						Computed:    true,
+						Default:     validatorutils.NewDefaultString(types.StringValue("")),
 						Description: "Optional link to include in the notification title.",
 					},
 					"text": schema.StringAttribute{
@@ -111,6 +117,8 @@ func (n *notifierResource) Schema(ctx context.Context, req resource.SchemaReques
 					},
 					"send_resolved": schema.BoolAttribute{
 						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
 						Description: "Send notifications when incident is resolved.",
 					},
 				},
@@ -126,6 +134,8 @@ func (n *notifierResource) Schema(ctx context.Context, req resource.SchemaReques
 					},
 					"send_resolved": schema.BoolAttribute{
 						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
 						Description: "Send notifications when incident is resolved.",
 					},
 				},
@@ -140,6 +150,8 @@ func (n *notifierResource) Schema(ctx context.Context, req resource.SchemaReques
 					},
 					"send_resolved": schema.BoolAttribute{
 						Optional:    true,
+						Computed:    true,
+						Default:     booldefault.StaticBool(false),
 						Description: "Send notifications when incident is resolved.",
 					},
 				},

--- a/internal/validatorutils/default_list.go
+++ b/internal/validatorutils/default_list.go
@@ -1,0 +1,40 @@
+package validatorutils
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type defaultList struct {
+	defaultValue types.List
+}
+
+var _ defaults.List = (*defaultList)(nil)
+
+func NewDefaultEmptyStringList() defaults.List {
+	var l []attr.Value
+	lv, _ := types.ListValue(basetypes.StringType{}, l)
+	return NewDefaultList(lv)
+}
+
+func NewDefaultList(defaultValue types.List) defaults.List {
+	return &defaultList{
+		defaultValue: defaultValue,
+	}
+}
+
+func (d defaultList) Description(ctx context.Context) string {
+	return "defaultList is a schema default value for types.List attributes."
+}
+
+func (d defaultList) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d defaultList) DefaultList(ctx context.Context, request defaults.ListRequest, response *defaults.ListResponse) {
+	response.PlanValue = d.defaultValue
+}

--- a/internal/validatorutils/default_list_test.go
+++ b/internal/validatorutils/default_list_test.go
@@ -1,0 +1,31 @@
+package validatorutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/rubrikinc/testwell/assert"
+)
+
+func TestDefaultList(t *testing.T) {
+	ctx := context.TODO()
+	var l []attr.Value
+	l = append(l, types.StringValue("foo"))
+	lv, diags := types.ListValue(basetypes.StringType{}, l)
+	assert.False(t, diags.HasError())
+
+	ds := NewDefaultList(lv)
+
+	resp := &defaults.ListResponse{}
+	req := defaults.ListRequest{}
+	ds.DefaultList(ctx, req, resp)
+	assert.DeepEqual(t, lv, resp.PlanValue)
+
+	nilDs := NewDefaultList(types.ListNull(basetypes.StringType{}))
+	nilDs.DefaultList(ctx, req, resp)
+	assert.True(t, resp.PlanValue.IsNull())
+}

--- a/internal/validatorutils/default_string.go
+++ b/internal/validatorutils/default_string.go
@@ -1,0 +1,32 @@
+package validatorutils
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type defaultString struct {
+	defaultValue types.String
+}
+
+var _ defaults.String = (*defaultString)(nil)
+
+func NewDefaultString(defaultValue types.String) defaults.String {
+	return &defaultString{
+		defaultValue: defaultValue,
+	}
+}
+
+func (d defaultString) Description(ctx context.Context) string {
+	return "defaultString is a schema default value for types.String attributes."
+}
+
+func (d defaultString) MarkdownDescription(ctx context.Context) string {
+	return d.Description(ctx)
+}
+
+func (d defaultString) DefaultString(ctx context.Context, request defaults.StringRequest, response *defaults.StringResponse) {
+	response.PlanValue = d.defaultValue
+}

--- a/internal/validatorutils/default_string_test.go
+++ b/internal/validatorutils/default_string_test.go
@@ -1,0 +1,25 @@
+package validatorutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/rubrikinc/testwell/assert"
+)
+
+func TestDefaultString(t *testing.T) {
+	ctx := context.TODO()
+	ds := NewDefaultString(types.StringValue("foo"))
+
+	resp := &defaults.StringResponse{}
+	req := defaults.StringRequest{}
+	ds.DefaultString(ctx, req, resp)
+
+	assert.Equal(t, "foo", resp.PlanValue.ValueString())
+
+	nilDs := NewDefaultString(types.StringNull())
+	nilDs.DefaultString(ctx, req, resp)
+	assert.True(t, resp.PlanValue.IsNull())
+}


### PR DESCRIPTION
For some option fields, terraform treats them as null
but after creating an object, the oodle API returns 
non null values (like false for booleans).

This creates inconsistent state in terraform as it sees
non null values when it expects a null.

This can be solved by setting default values.