### PR TITLE
Fix grouping attributes

### DIFF
--- a/docs/resources/monitor.md
+++ b/docs/resources/monitor.md
@@ -140,7 +140,7 @@ Optional:
 <a id="nestedatt--grouping"></a>
 ### Nested Schema for `grouping`
 
-Required:
+Optional:
 
 - `by_labels` (List of String) List of labels to group by. One notification is sent for each unique grouping when the monitor fires.
 - `by_monitor` (Boolean) If true, only one notification will be sent for this monitor irrespective of how many series match.

--- a/examples/e2e/main.tf
+++ b/examples/e2e/main.tf
@@ -105,6 +105,10 @@ resource "oodle_monitor" "service_monitor" {
     runbook_url = "https://wiki.example.com/runbooks/service-errors"
   }
 
+  grouping = {
+    disabled = true
+  }
+
   # Default policy for alerts that don't match any matchers
   notification_policy_id = oodle_notification_policy.default.id
 

--- a/internal/provider/oresource/monitor/model_monitor_test.go
+++ b/internal/provider/oresource/monitor/model_monitor_test.go
@@ -47,8 +47,7 @@ func TestMonitorModel(t *testing.T) {
 			"test7": "test8",
 		},
 		Grouping: clientmodels.Grouping{
-			ByLabels:  []string{"test9", "test10"},
-			ByMonitor: true,
+			ByLabels: []string{"test9", "test10"},
 		},
 		NotificationPolicyID: &clientmodels.ID{
 			UUID: uuid.New(),

--- a/internal/provider/oresource/monitor/monitor_resource.go
+++ b/internal/provider/oresource/monitor/monitor_resource.go
@@ -176,18 +176,21 @@ func (r *monitorResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"by_monitor": schema.BoolAttribute{
-						Required:    true,
+						Optional:    true,
 						Description: "If true, only one notification will be sent for this monitor irrespective of how many series match.",
 					},
 					"by_labels": schema.ListAttribute{
-						Required:    true,
+						Optional:    true,
 						ElementType: types.StringType,
 						Description: "List of labels to group by. One notification is sent for each unique grouping when the monitor fires.",
 					},
 					"disabled": schema.BoolAttribute{
-						Required:    true,
+						Optional:    true,
 						Description: "If true, grouping is disabled.",
 					},
+				},
+				Validators: []validator.Object{
+					validatorutils.NewGroupingValidator(),
 				},
 			},
 			"notification_policy_id": schema.StringAttribute{

--- a/internal/validatorutils/grouping_validator.go
+++ b/internal/validatorutils/grouping_validator.go
@@ -1,0 +1,75 @@
+package validatorutils
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type groupingValidator struct {
+}
+
+var _ validator.Object = (*groupingValidator)(nil)
+
+func NewGroupingValidator() validator.Object {
+	return &groupingValidator{}
+}
+
+func (g groupingValidator) Description(ctx context.Context) string {
+	return "Validates that exactly one of by_monitor, by_labels, or disabled is specified in grouping"
+}
+
+func (g groupingValidator) MarkdownDescription(ctx context.Context) string {
+	return g.Description(ctx)
+}
+
+func (g groupingValidator) ValidateObject(
+	ctx context.Context,
+	request validator.ObjectRequest,
+	response *validator.ObjectResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	attrs := request.ConfigValue.Attributes()
+	if attrs == nil {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Missing grouping attributes",
+			"The grouping must contain exactly one of by_monitor, by_labels, or disabled",
+		)
+		return
+	}
+
+	// Count how many are set (not null)
+	count := 0
+
+	// Check each field
+	if byMonitorAttr, ok := attrs["by_monitor"]; ok && !byMonitorAttr.IsNull() {
+		count++
+	}
+	if byLabelsAttr, ok := attrs["by_labels"]; ok && !byLabelsAttr.IsNull() {
+		count++
+	}
+	if disabledAttr, ok := attrs["disabled"]; ok && !disabledAttr.IsNull() {
+		count++
+	}
+
+	if count == 0 {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"No grouping type specified",
+			"Exactly one of by_monitor, by_labels, or disabled must be specified in grouping",
+		)
+		return
+	}
+
+	if count > 1 {
+		response.Diagnostics.AddAttributeError(
+			request.Path,
+			"Multiple grouping types specified",
+			"Only one of by_monitor, by_labels, or disabled can be specified in grouping",
+		)
+	}
+}

--- a/internal/validatorutils/grouping_validator_test.go
+++ b/internal/validatorutils/grouping_validator_test.go
@@ -1,0 +1,135 @@
+package validatorutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/rubrikinc/testwell/assert"
+)
+
+func TestGroupingValidator(t *testing.T) {
+	v := NewGroupingValidator()
+	ctx := context.Background()
+
+	// Test valid cases - exactly one field set
+	testCases := []struct {
+		name        string
+		attrs       map[string]attr.Value
+		shouldError bool
+	}{
+		{
+			name: "disabled only",
+			attrs: map[string]attr.Value{
+				"disabled":   types.BoolValue(true),
+				"by_monitor": types.BoolNull(),
+				"by_labels":  types.ListNull(types.StringType),
+			},
+			shouldError: false,
+		},
+		{
+			name: "by_monitor only",
+			attrs: map[string]attr.Value{
+				"disabled":   types.BoolNull(),
+				"by_monitor": types.BoolValue(true),
+				"by_labels":  types.ListNull(types.StringType),
+			},
+			shouldError: false,
+		},
+		{
+			name: "by_labels only",
+			attrs: map[string]attr.Value{
+				"disabled":   types.BoolNull(),
+				"by_monitor": types.BoolNull(),
+				"by_labels": types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("service"),
+					types.StringValue("region"),
+				}),
+			},
+			shouldError: false,
+		},
+		{
+			name: "multiple fields set",
+			attrs: map[string]attr.Value{
+				"disabled":   types.BoolValue(true),
+				"by_monitor": types.BoolValue(true),
+				"by_labels":  types.ListNull(types.StringType),
+			},
+			shouldError: true,
+		},
+		{
+			name: "all fields set",
+			attrs: map[string]attr.Value{
+				"disabled":   types.BoolValue(true),
+				"by_monitor": types.BoolValue(true),
+				"by_labels": types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("service"),
+				}),
+			},
+			shouldError: true,
+		},
+		{
+			name: "no fields set",
+			attrs: map[string]attr.Value{
+				"disabled":   types.BoolNull(),
+				"by_monitor": types.BoolNull(),
+				"by_labels":  types.ListNull(types.StringType),
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objType := types.ObjectType{
+				AttrTypes: map[string]attr.Type{
+					"disabled":   types.BoolType,
+					"by_monitor": types.BoolType,
+					"by_labels":  types.ListType{ElemType: types.StringType},
+				},
+			}
+
+			objValue, diags := types.ObjectValue(objType.AttrTypes, tc.attrs)
+			assert.False(t, diags.HasError(), "Failed to create test object: %v", diags)
+
+			req := validator.ObjectRequest{
+				ConfigValue: objValue,
+			}
+			resp := &validator.ObjectResponse{}
+
+			v.ValidateObject(ctx, req, resp)
+
+			if tc.shouldError {
+				assert.True(t, resp.Diagnostics.HasError(), "Expected validation error for case: %s", tc.name)
+			} else {
+				assert.False(t, resp.Diagnostics.HasError(), "Unexpected validation error for case: %s, errors: %v", tc.name, resp.Diagnostics)
+			}
+		})
+	}
+
+	// Test null object (should pass)
+	req := validator.ObjectRequest{
+		ConfigValue: types.ObjectNull(map[string]attr.Type{
+			"disabled":   types.BoolType,
+			"by_monitor": types.BoolType,
+			"by_labels":  types.ListType{ElemType: types.StringType},
+		}),
+	}
+	resp := &validator.ObjectResponse{}
+	v.ValidateObject(ctx, req, resp)
+	assert.False(t, resp.Diagnostics.HasError(), "Null object should not produce validation errors")
+
+	// Test unknown object (should pass)
+	req = validator.ObjectRequest{
+		ConfigValue: types.ObjectUnknown(map[string]attr.Type{
+			"disabled":   types.BoolType,
+			"by_monitor": types.BoolType,
+			"by_labels":  types.ListType{ElemType: types.StringType},
+		}),
+	}
+	resp = &validator.ObjectResponse{}
+	v.ValidateObject(ctx, req, resp)
+	assert.False(t, resp.Diagnostics.HasError(), "Unknown object should not produce validation errors")
+}


### PR DESCRIPTION
Grouping could be one of: by_monitor, by_labels, disabled (by timeseries). Currently, all fields were required, make them optional and add a validation that at least one of them is set.